### PR TITLE
override test command in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,6 @@ deployment:
     branch: master
     heroku:
       appname: santander-cycles
+test:
+  override:
+    - bundle exec rspec


### PR DESCRIPTION
need to `bundle exec rspec` without the `format progress` bit.  
At the moment this is specified via the circle dashboard GUI - better to specify it in the circle.yml
See http://stackoverflow.com/questions/23617909/rspec-fails-with-invalid-option-even-though-the-option-is-valid-is-this-a-bug for more info.