### PR TITLE
add error notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.3.2'
 
 gem 'rest-client'
 gem 'rake'
+gem 'airbrake', '~> 5.6'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,9 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    airbrake (5.6.1)
+      airbrake-ruby (~> 1.6)
+    airbrake-ruby (1.6.0)
     codeclimate-test-reporter (1.0.3)
       simplecov
     crack (0.4.3)
@@ -57,6 +60,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (~> 5.6)
   codeclimate-test-reporter (~> 1.0.0)
   dotenv
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'airbrake'
 require 'bikepoint'
 require 'markdown'
 
@@ -11,6 +12,11 @@ namespace 'notify' do
   task :slack do
     SlackNotifier.notify
   end
+end
+
+Airbrake.configure do |c|
+  c.project_id = 133_461
+  c.project_key = '47baf0b45c8229718715b07edee4b9e8'
 end
 
 desc 'Generate "BIKEPOINTS.md" with list of all Santander Cycles bikepoint names'


### PR DESCRIPTION
If the app errors then I want to be notified.
[Airbrake](https://devcenter.heroku.com/articles/airbrake) could be a good option.  Its [free plan](https://elements.heroku.com/addons/airbrake#pricing) includes webhooks, which means that I can hopefully set up a [Slack notification webhook](https://api.slack.com/incoming-webhooks).